### PR TITLE
Avoid repeated records when generating changesets using `since`

### DIFF
--- a/lib/hive_crdt.dart
+++ b/lib/hive_crdt.dart
@@ -34,6 +34,11 @@ class HiveCrdt<K, V> extends Crdt<K, V> {
             record.modified.logicalTime < (modifiedSince?.logicalTime ?? 0)))
       .map((key, value) => MapEntry(_decode(key), value as Record<V>));
 
+  Map<K, Record<V>> recordMapAfter(Hlc modifiedAfter) => (_box.toMap()
+        ..removeWhere((_, record) =>
+            record.modified.logicalTime <= (modifiedAfter.logicalTime ?? 0)))
+      .map((key, value) => MapEntry(_decode(key), value as Record<V>));
+
   @override
   Stream<MapEntry<K, V?>> watch({K? key}) => _box
       .watch(key: key)

--- a/lib/hive_crdt.dart
+++ b/lib/hive_crdt.dart
@@ -31,12 +31,7 @@ class HiveCrdt<K, V> extends Crdt<K, V> {
   @override
   Map<K, Record<V>> recordMap({Hlc? modifiedSince}) => (_box.toMap()
         ..removeWhere((_, record) =>
-            record.modified.logicalTime < (modifiedSince?.logicalTime ?? 0)))
-      .map((key, value) => MapEntry(_decode(key), value as Record<V>));
-
-  Map<K, Record<V>> recordMapAfter(Hlc modifiedAfter) => (_box.toMap()
-        ..removeWhere((_, record) =>
-            record.modified.logicalTime <= (modifiedAfter.logicalTime ?? 0)))
+            record.modified.logicalTime <= (modifiedSince?.logicalTime ?? 0)))
       .map((key, value) => MapEntry(_decode(key), value as Record<V>));
 
   @override

--- a/test/hive_crdt_test.dart
+++ b/test/hive_crdt_test.dart
@@ -71,23 +71,10 @@ void main() {
       final hlc = crdt.canonicalTime;
       crdt.put('c', 3);
       final map = crdt.recordMap(modifiedSince: hlc);
-      expect(map.length, 2);
+      expect(map.length, 1);
       expect(map['a'], isNull);
-      expect(map['b']!.value, 2);
+      expect(map['b'], isNull);
       expect(map['c']!.value, 3);
-    });
-
-    test('After', () {
-      crdt.put('a', 1);
-      crdt.put('b', 2);
-      final hlc = crdt.canonicalTime;
-      crdt.put('c', 3);
-
-      final mapAfter = crdt.recordMapAfter(hlc);
-      expect(mapAfter.length, 1);
-      expect(mapAfter['a'], isNull);
-      expect(mapAfter['b'], isNull);
-      expect(mapAfter['c']!.value, 3);
     });
 
     test('All', () {
@@ -104,7 +91,7 @@ void main() {
       final hlc = crdt.canonicalTime;
       crdt.put('c', 3);
       final json = crdt.toJson(modifiedSince: hlc);
-      expect(json, startsWith('{"b":{"hlc":'));
+      expect(json, startsWith('{"c":{"hlc":'));
       expect(json, endsWith(',"value":3}}'));
     });
 

--- a/test/hive_crdt_test.dart
+++ b/test/hive_crdt_test.dart
@@ -77,6 +77,19 @@ void main() {
       expect(map['c']!.value, 3);
     });
 
+    test('After', () {
+      crdt.put('a', 1);
+      crdt.put('b', 2);
+      final hlc = crdt.canonicalTime;
+      crdt.put('c', 3);
+
+      final mapAfter = crdt.recordMapAfter(hlc);
+      expect(mapAfter.length, 1);
+      expect(mapAfter['a'], isNull);
+      expect(mapAfter['b'], isNull);
+      expect(mapAfter['c']!.value, 3);
+    });
+
     test('All', () {
       crdt.put('a', 1);
       crdt.put('b', 2);


### PR DESCRIPTION
Kindly consider adding the records after the HLC timestamp.